### PR TITLE
Fix rustls provider setup

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,5 +12,5 @@ tungstenite        = { version = "0.27", default-features = false, features = ["
 
 anyhow = "1.0.98"
 dotenvy = "0.15"
-rustls = "0.23.29"
+rustls = { version = "0.23.29", features = ["ring"] }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,23 +6,12 @@ use axum::{routing::any,
         };
 use crate::routes::handle_ws;
 
-use std::sync::Arc;
-use rustls::crypto::CryptoProvider;
+use rustls::crypto::ring;
 
 #[tokio::main]
 async fn main() {
-    // 1) Grab the Arc<CryptoProvider>
-    let provider_arc = CryptoProvider::get_default()
-        .expect("No default CryptoProvider available");
-
-    // 2) Clone the inner `CryptoProvider` (leaves `provider_arc` intact)
-    let provider_clone = <CryptoProvider as Clone>::clone(&*provider_arc);
-    //                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    // this calls the `Clone` impl on `CryptoProvider`,
-    // not on the Arc itself
-
-    // 3) Move that clone into install_default()
-    provider_clone
+    // Install the ring-based crypto provider so rustls can operate.
+    ring::default_provider()
         .install_default()
         .expect("Failed to install CryptoProvider");
 


### PR DESCRIPTION
## Summary
- enable ring feature for rustls
- install ring CryptoProvider at startup so backend runs

## Testing
- `cargo run --manifest-path backend/Cargo.toml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6876ea11fefc832abb3c01e2d459783f